### PR TITLE
Added the args option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ be the same by default, but specifying `duplicates: true` would yield:
 }
 ```
 
+`args`: If specified, it is assumed that all loaded modules export a single function that should be directly invoked with the provided value (passed as is as a single parameter). If any of the loaded modules does not return a function, an error is thrown. Example assuming that modules 'a' and 'b' are present in the specified directory:
+```js
+
+// ./path/to/dir/a.js
+module.exports = function(args){
+    console.log(args); // 'foo'
+};
+
+// ./path/to/dir/b.js
+module.exports = function(args){
+    console.log(args); // 'foo'
+};
+
+// loading
+requireDir('./path/to/dir', {args: 'foo'});
+// 'a' and 'b' will be loaded and the function they return will be invoked as follows:
+// require('./path/to/dir/a.js')('foo');
+// require('./path/to/dir/b.js')('foo');
+```
+
 There might be more options in the future. ;)
 
 ## Tips

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { "name": "require-dir"
 , "description": "Helper to require() directories."
-, "version": "0.3.0"
+, "version": "0.4.0"
 , "author": "Aseem Kishore <aseem.kishore@gmail.com>"
 , "license": "MIT"
 , "dependencies": {}

--- a/test/args.js
+++ b/test/args.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+var foo = 'foo';
+var bar = 'bar';
+var dummy = {a: foo, b: bar};
+
+// validate that a given argument is passed to all loaded modules as is
+assert.deepEqual(requireDir('./args', {args: foo}), {a: foo, b: foo});
+assert.deepEqual(requireDir('./args', {args: [foo,bar]}), {a: [foo,bar], b: [foo,bar]});
+assert.deepEqual(requireDir('./args', {args: dummy}), { a: dummy, b: dummy });
+
+console.log('Args tests passed.');

--- a/test/args/a.js
+++ b/test/args/a.js
@@ -1,0 +1,3 @@
+module.exports = function(args){
+	return args;
+};

--- a/test/args/b.js
+++ b/test/args/b.js
@@ -1,0 +1,3 @@
+module.exports = function(args){
+	return args;
+};


### PR DESCRIPTION
The args option can be used as a short-hand way of passing some
value/object to all loaded modules (assuming they all export a function
that can be directly invoked)

Fix for #15 
