### PR TITLE
Added new options "append", "prepend", "cleanup" and "transform"

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,44 @@ module.exports = function requireDir(dir, opts) {
         }
     }
 
+    if(opts.append) {
+
+        for(var base in map) {
+            // protect against enumerable object prototype extensions:
+            if (!map.hasOwnProperty(base)) {
+                continue;
+            }
+
+            map[base + opts.append] = map[base];
+            if(opts.cleanup) {
+                delete map[base];
+            }
+        }
+
+    }
+
+    if(opts.prepend) {
+
+        for(var base in map) {
+            // protect against enumerable object prototype extensions:
+            if (!map.hasOwnProperty(base)) {
+                continue;
+            }
+
+            map[opts.prepend + base] = map[base];
+            if(opts.cleanup) {
+                delete map[base];
+            }
+        }
+
+    }
+
+    // if transform:camelcase is set, skip the old way to avoid clutter
+    if(opts.transform && opts.transform.indexOf('camelcase') !== -1) {
+        opts.camelcase = false;
+    }
+
+    // kept for compatibility reasons
     if (opts.camelcase) {
         for (var base in map) {
             // protect against enumerable object prototype extensions:
@@ -128,6 +166,30 @@ module.exports = function requireDir(dir, opts) {
             }
 
             map[toCamelCase(base)] = map[base];
+        }
+    }
+
+    if(opts.transform) {
+
+        for(var base in map) {
+            // protect against enumerable object prototype extensions:
+            if (!map.hasOwnProperty(base)) {
+                continue;
+            }
+
+            var transformedBase = base;
+            if(opts.transform.indexOf('camelcase') !== -1) {
+                transformedBase = toCamelCase(transformedBase);
+            }
+
+            if(opts.transform.indexOf('ucfirst') !== -1) {
+                transformedBase = transformedBase.split('').shift().toUpperCase() + transformedBase.slice(1);
+            }
+
+            map[transformedBase] = map[base];
+            if(opts.cleanup && transformedBase !== base) {
+                delete map[base];
+            }
         }
     }
 

--- a/test/append.js
+++ b/test/append.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+assert.deepEqual(requireDir('./append', {
+	append: 'Appended'
+}), {
+	a: 'a',
+	b: 'b',
+    aAppended: 'a',
+    bAppended: 'b',
+});
+
+console.log('Append tests passed.');

--- a/test/append/a.js
+++ b/test/append/a.js
@@ -1,0 +1,1 @@
+module.exports = 'a';

--- a/test/append/b.js
+++ b/test/append/b.js
@@ -1,0 +1,1 @@
+module.exports = 'b';

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+assert.deepEqual(requireDir('./prepend', {
+	prepend: 'prepend'
+}), {
+	a: 'a',
+	b: 'b',
+    prependa: 'a',
+    prependb: 'b',
+});
+
+assert.deepEqual(requireDir('./prepend', {
+	prepend: 'prepend',
+	cleanup: true
+}), {
+    prependa: 'a',
+    prependb: 'b',
+});
+
+assert.deepEqual(requireDir('./prepend', {
+	prepend: 'prepend-',
+	transform: 'camelcase',
+	cleanup: true
+}), {
+	prependA: 'a',
+	prependB: 'b'
+});
+
+assert.deepEqual(requireDir('./prepend', {
+	prepend: 'prepend-',
+	transform: ['camelcase', 'ucfirst'],
+}), {
+	a: 'a',
+	b: 'b',
+	'prepend-a': 'a',
+	'prepend-b': 'b',
+	A: 'a',
+	B: 'b',
+	PrependA: 'a',
+	PrependB: 'b'
+});
+
+console.log('Prepend tests passed.');

--- a/test/prepend/a.js
+++ b/test/prepend/a.js
@@ -1,0 +1,1 @@
+module.exports = 'a';

--- a/test/prepend/b.js
+++ b/test/prepend/b.js
@@ -1,0 +1,1 @@
+module.exports = 'b';

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,0 +1,54 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+assert.deepEqual(requireDir('./transform', {
+    recurse: true,
+    transform: ['camelcase']
+}), {
+    aMain: 'a main',
+    'a_main': 'a main',
+    subDir: {
+        aSub: 'a sub',
+        'a-sub': 'a sub'
+    },
+    'sub-dir': {
+        aSub: 'a sub',
+        'a-sub': 'a sub'
+    }
+});
+
+
+assert.deepEqual(requireDir('./transform', {
+    recurse: true,
+    transform: ['ucfirst']
+}), {
+    a_main: 'a main',
+    'sub-dir': {
+        'a-sub': 'a sub',
+        'A-sub': 'a sub'
+    },
+    A_main: 'a main',
+    'Sub-dir': {
+        'a-sub': 'a sub',
+        'A-sub': 'a sub'
+    }
+});
+
+assert.deepEqual(requireDir('./transform', {
+    recurse: true,
+    transform: ['ucfirst', 'camelcase']
+}), {
+    a_main: 'a main',
+    'sub-dir': {
+        'a-sub': 'a sub',
+        ASub: 'a sub'
+    },
+    AMain: 'a main',
+    SubDir: {
+        'a-sub': 'a sub',
+        ASub: 'a sub'
+    }
+});
+
+
+console.log('Transform tests passed.');

--- a/test/transform/a_main.js
+++ b/test/transform/a_main.js
@@ -1,0 +1,1 @@
+module.exports = 'a main';

--- a/test/transform/sub-dir/a-sub.js
+++ b/test/transform/sub-dir/a-sub.js
@@ -1,0 +1,1 @@
+module.exports = 'a sub';


### PR DESCRIPTION
Hey,

I needed a way to differ between modules from different folders (in my case _controllers_ and _models_) which made me add an `append` option:

```
var requireDir = require('require-dir');
var _ = require('lodash');

var models = requireDir('./models', {append: 'Model', cleanup: true});
var controllers = requireDir('./controllers', {append: 'Controller', cleanup: true});

console.log(_.merge(models, controllers));
```

=> `{ aModel: 'a', bModel: 'b', aController: 'a', bController: 'b' }`

I also added a new option `transform` since I wanted my modules to be compliant with my UpperCamelCase convention, so I added `transform: 'ucfirst'` as new option which will return `Login` if the file is named 'login.js'

And because it's nothing else than another transformation-style I also allowed `camelcase` to be used as value for the transform option: `{ transform: ['camelcase', 'ucfirst'] }` (or simply `{ transform: 'camelcase ucfirst' }` since it is a simple indexOf lookup). I did not remove the old `camelcase` option to be backwards compatible.

To avoid having confusing module names with the same name in the returned object, I also added another option `cleanup` which removes modules which were renamed using a `transform`, `append` or `prepend`.

I added tests for every new option to make sure nothing breaks. All new options are of course optional and everything should be completely backwards compatible so it can be merged safely :)
