### PR TITLE
Support a filter option to exclude particular files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ be the same by default, but specifying `duplicates: true` would yield:
 }
 ```
 
+`filter`: Apply a filter on the filename before require-ing. For example:
+
+```js
+requiredir('./dir', function (f) { return process.env.NODE_ENV !== 'production' && !f.match(/$dev/); })
+```
+
+This will ignore files prefixed with `dev` if running in a production environment.
+
 There might be more options in the future. ;)
 
 ## Tips

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ module.exports = function requireDir(dir, opts) {
     dir = dir || '.';
     opts = opts || {};
 
+    opts.filter = opts.filter || function (file) { return true; };
+
     // resolve the path to an absolute one:
     dir = Path.resolve(parentDir, dir);
 
@@ -64,6 +66,10 @@ module.exports = function requireDir(dir, opts) {
 
             // ignore the calling file:
             if (path === parentFile) {
+                continue;
+            }
+            // apply file filter:
+            if (!opts.filter(path)) {
                 continue;
             }
 

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+// filter the results to a particular file:
+assert.deepEqual(requireDir('./simple', { filter: function (filename) { return filename.match(/a\.js$/); } }), {
+    a: 'a'
+});
+
+console.log('Filter tests passed.');


### PR DESCRIPTION
We're using require-dir to load a directory of gulp tasks. However, we want to be able to exclude certain files from being required when executed in a production environment as they include dependencies that might not be installed.

Being able to apply a filter like `function (f) { return process.env.NODE_ENV !== 'production' && !f.match(/$dev/); }` would mean we can just ignore any dev-only task from the directory when run in a prod environment.
