### PR TITLE
Add noCache option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,9 @@ module.exports = function requireDir(dir, opts) {
                 // also the base if it hasn't been taken yet (since this ext
                 // has higher priority than any that follow it). if duplicates
                 // aren't wanted, we're done with this basename.
+                if (opts.noCache) {
+                    delete require.cache[path];
+                }
                 if (opts.duplicates) {
                     map[file] = require(path);
                     if (!map[base]) {


### PR DESCRIPTION
Add option to prevent module caching. Super useful when used in continuous streams or with servers &mdash; no more restarting task or server to see updates to certain files.