### PR TITLE
support for params

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,12 +108,18 @@ module.exports = function requireDir(dir, opts) {
                 // has higher priority than any that follow it). if duplicates
                 // aren't wanted, we're done with this basename.
                 if (opts.duplicates) {
-                    map[file] = require(path);
+					map[file] = require(path);
+					if(opts.params && map[file].apply){
+						map[file] = map[file].apply(this,opts.params);
+					}
                     if (!map[base]) {
                         map[base] = map[file];
                     }
                 } else {
-                    map[base] = require(path);
+					map[base] = require(path);
+					if(opts.params && map[base].apply){
+						map[base] = map[base].apply(this,opts.params);
+					}
                     break;
                 }
             }

--- a/test/params.js
+++ b/test/params.js
@@ -1,0 +1,10 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+assert.deepEqual(requireDir('./params',{params:['just a param']}), {
+    a: 'a',
+	b: 'just a param',
+	c: 'c'
+});
+
+console.log('Params tests passed.');

--- a/test/params/a.js
+++ b/test/params/a.js
@@ -1,0 +1,3 @@
+module.exports = function(){
+	return 'a';
+};

--- a/test/params/b.js
+++ b/test/params/b.js
@@ -1,0 +1,3 @@
+module.exports = function(someString){
+	return someString;
+};

--- a/test/params/c.js
+++ b/test/params/c.js
@@ -1,0 +1,1 @@
+module.exports = 'c';


### PR DESCRIPTION
Support for params through apply for function modules.

Example:

``` javascript
require('require-dir')('./tasks',{'params':[someArg1, someArg2, someArg3]});
```
