### PR TITLE
module.parent.filename can be undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var Path = require('path');
 // paths. this only works if a fresh version of this module is run on every
 // require(), so important: we clear the require() cache each time!
 var parent = module.parent;
-var parentFile = parent.filename;
+var parentFile = parent.filename || "";
 var parentDir = Path.dirname(parentFile);
 delete require.cache[__filename];
 


### PR DESCRIPTION
Hello!

I think the issue I experienced today is kind of a rare one, but it may happen to anyone else as it did for me. I am not sure what exactly causes `module.parent.filename` to be `undefined`, but when I `require`d `require-dir` from the Intellij IDEA command line, it gave me the following (I am using [cmder](http://cmder.net)):

```bash
Z:\ZitRos\Projects\TimingKit (master) (zitronic-timing-kit@0.34.7)
λ node --version
v8.0.0

Z:\ZitRos\Projects\TimingKit (master) (zitronic-timing-kit@0.34.7)
λ node
> const requireDir = require("require-dir");
TypeError: Path must be a string. Received null
    at assertPath (path.js:28:11)
    at Object.dirname (path.js:716:5)
    at Object.<anonymous> (Z:\ZitRos\Projects\TimingKit\node_modules\require-dir\index.js:12:22)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)

```

The change I propose fixes this problem: it just defaults filename to an empty string, which works as expected:

```bash
> let requireDir = require("require-dir");
undefined
> Object.keys(requireDir("."))
[ 'package-lock', 'package' ]
```

Thanks!