### PR TITLE
Resolve #59, add an optional extensions parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ be the same by default, but specifying `duplicates: true` would yield:
 requireDir('./dir', { noCache: true })
 ```
 
+`extensions`: Array of extensions to look for instead of using `require.extensions`.
+
+```js
+requireDir('./dir', { extensions: ['.js', '.json'] })
+```
+
 ## Tips
 
 Make an `index.js` in a directory with this code to clean things up:

--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ module.exports = function requireDir(dir, opts) {
     // to the map using the full filename as a key also.
     var map = {};
 
+    // get the array of extensions we need to require
+    var extensions = opts.extensions || Object.keys(require.extensions);
+
     for (var base in filesForBase) {
         // protect against enumerable object prototype extensions:
         if (!filesForBase.hasOwnProperty(base)) {
@@ -95,13 +98,7 @@ module.exports = function requireDir(dir, opts) {
         }
 
         // otherwise, go through and try each require.extension key!
-        for (ext in require.extensions) {
-            // Node v8+ uses "clean" objects w/o hasOwnProperty for require
-            // again protect against enumerable object prototype extensions:
-            if (!Object.prototype.hasOwnProperty.call(require.extensions, ext)) {
-                continue;
-            }
-
+        for (ext of extensions) {
             // if a file exists with this extension, we'll require() it:
             var file = base + ext;
             var abs = filesMinusDirs[file];

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+var requireDir = require('..');
+
+// first test regularly:
+assert.deepEqual(requireDir('./simple'), {
+    a: 'a',
+    b: 'b',
+});
+
+// only js files
+assert.deepEqual(requireDir('./simple', {extensions: ['.js']}), {
+    a: 'a'
+});
+
+// both js and json files
+assert.deepEqual(requireDir('./simple', {extensions: ['.js', '.json']}), {
+    a: 'a',
+    b: 'b'
+});
+
+// then test with recursing:
+assert.deepEqual(requireDir('./recurse', {recurse: true, extensions: ['.js']}), {
+    a: 'a',
+    b: {
+        '1': {
+            foo: 'foo'
+        },
+        '2': {}     // note how the directory is always returned
+    },
+    c: {}
+    // note that node_modules was explicitly ignored
+});
+
+console.log('Extensions tests passed.');


### PR DESCRIPTION
Added an optional array `extensions` to declare the extensions we'd like to require.
All tests are green with both node v0.12 and node v10. I expect them to run on all major version but I did not try them all.

In order to keep the code simple, I replace the object iteration by an array iteration (using Object.keys), since anyway we were never using the values of the object.