### PR TITLE
Import index file in path without recurse

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ requireDir('./dir', { noCache: true })
 requireDir('./dir', { extensions: ['.js', '.json'] })
 ```
 
+`indexFile`: Allow import index file in path without `recurse`
+
+```txt
+./
+ ┣ modules
+ ┃ ┣ a.js
+ ┃ ┣ b.js
+ ┃ ┗ index.js
+ ┗ app.js
+```
+
+```js
+requireDir('./', { indexFile: true })
+
+// Return
+{
+  modules: require('./modules')
+}
+```
+
 ## Tips
 
 Make an `index.js` in a directory with this code to clean things up:

--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ requireDir('./dir', { extensions: ['.js', '.json'] })
 ```txt
 ./
  ┣ modules
- ┃ ┣ a.js
  ┃ ┣ b.js
+ ┃ ┣ c.js
  ┃ ┗ index.js
+ ┣ a.js
  ┗ app.js
 ```
 
@@ -139,6 +140,7 @@ requireDir('./', { indexFile: true })
 
 // Return
 {
+  a: require('./a.js'),
   modules: require('./modules')
 }
 ```

--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ module.exports = function requireDir(dir, opts) {
                     if (opts.duplicates) {
                         map[file] = map[base];
                     }
+                } else if (opts.indexFile) {
+                    // if indexFile allow, keep abs to import index file in path
+                    filesMinusDirs[file] = abs
                 }
             } else {
                 filesMinusDirs[file] = abs;
@@ -102,11 +105,16 @@ module.exports = function requireDir(dir, opts) {
             // if a file exists with this extension, we'll require() it:
             var file = base + ext;
             var abs = filesMinusDirs[file];
+            
+            if (opts.indexFile && filesMinusDirs[base]) {
+                file = base;
+                abs = filesMinusDirs[base]
+            }
 
             if (abs) {
                 // ignore TypeScript declaration files. They should never be
                 // `require`d
-                if (/\.d\.ts$/.test(abs)) {
+                if (/\.d\.ts$/.test(abs) && !fs.statSync(abs).isDirectory()) {
                     continue;
                 }
 

--- a/test/indexFile.js
+++ b/test/indexFile.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const requireDir = require('..');
+
+// first test without indexFile allowed:
+assert.deepEqual(requireDir('./indexFile'), {
+  a: 'a'
+})
+
+// then test with indexFile allowed
+assert.deepEqual(requireDir('./indexFile', { indexFile: true }), {
+  a: 'a',
+  modules: {
+    b: 'b',
+    c: 'c'
+  }
+});
+
+console.log('indexFile test passed');

--- a/test/indexFile/a.js
+++ b/test/indexFile/a.js
@@ -1,0 +1,1 @@
+module.exports = 'a';

--- a/test/indexFile/modules/b.js
+++ b/test/indexFile/modules/b.js
@@ -1,0 +1,1 @@
+module.exports = 'b';

--- a/test/indexFile/modules/c.js
+++ b/test/indexFile/modules/c.js
@@ -1,0 +1,1 @@
+module.exports = 'c';

--- a/test/indexFile/modules/index.js
+++ b/test/indexFile/modules/index.js
@@ -1,0 +1,4 @@
+const b = require('./b');
+const c = require('./c');
+
+module.exports = { b, c };


### PR DESCRIPTION
Added flag and logic to import index file in path without `recurse` flag

Sometimes can use a folder to group a modules and keep clean files structures, we can't import a index file (if exists) from the path without `recurse` flag.

```txt
./
 ┣ modules
 ┃ ┣ b.js
 ┃ ┣ c.js
 ┃ ┗ index.js
 ┣ a.js
 ┗ app.js
```

```js
requireDir('./', { indexFile: true })

// Return
{
  a: require('./a.js'),
  modules: require('./modules')
}
```